### PR TITLE
Fix dead benchmark url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The troubleshooting area on http://www.atnf.csiro.au/vlbi/dokuwiki/doku.php/difx
 
 #### TESTING ####################
 
-See http://www.atnf.csiro.au/dokuwiki/doku.php/difx/benchmarks
+See https://www.atnf.csiro.au/vlbi/dokuwiki/doku.php/difx/benchmarking
 
 ## Usage
 


### PR DESCRIPTION
URL doesn't work. Replaced with what I think the correct URL is.